### PR TITLE
Update all blueprints in books

### DIFF
--- a/modules/blueprints.lua
+++ b/modules/blueprints.lua
@@ -10,29 +10,65 @@ local util = require('util')
 blueprints.updateBlueprint = function(playerIndex, replacerFunction)
     --get the player
     local player = game.players[playerIndex]
-    --check if the player has a blueprint selected return if not
-    if not player.is_cursor_blueprint() then return end
-
-    --check if player is really holding a blueprint item stack
-    local blueprintStack = player.cursor_stack
-    --Return if blueprintStack is null or not valid_for_read
-    if not blueprintStack then return end
-    if not blueprintStack.valid_for_read then return end
-    --get blueprint entities
-    local blueprintEntities = player.get_blueprint_entities()
-    if not blueprintEntities then return end
-    --return if blueprintEntities is empty
-    if # blueprintEntities == 0 then return end
-    --replace blueprint entities with dummy entities using table.map
-    
-    local dummyEntities = table.map(blueprintEntities, replacerFunction)
-
-    --set the blueprint entities
-    local itemStack = player.cursor_stack
-    local blueprint = Inventory.get_blueprint(itemStack)
-    blueprint.set_blueprint_entities(dummyEntities)
-
+    --check if player is holding a single blueprint or a book
+    if player.cursor_stack.is_blueprint then
+       blueprints.updateSingleBlueprint(player.cursor_stack, replacerFunction)
+    elseif player.cursor_stack.is_blueprint_book then
+       blueprints.updateBlueprintBook(player.cursor_stack, replacerFunction)
+    end
+    --otherwise, do nothing
 end
+
+--- Update a single blueprint, applying the replacerFunction to every entity in the blueprint.
+-- @tparam LuaItemStack blueprint
+-- @tparam func replacerFunction
+blueprints.updateSingleBlueprint = function(blueprint, replacerFunction)
+    --Safety checks: make sure stack is a blueprint and valid
+   if not blueprint then return end
+   if not blueprint.valid_for_read then return end
+   if not blueprint.is_blueprint then return end
+   if not blueprint.is_blueprint_setup() then return end
+
+   --get blueprint entities
+   local blueprintEntities = blueprint.get_blueprint_entities()
+   --return if blueprintEntities is empty
+   if # blueprintEntities == 0 then return end
+
+   --replace blueprint entities with dummy entities using table.map
+   local dummyEntities = table.map(blueprintEntities, replacerFunction)
+
+   --set the blueprint entities
+   blueprint.set_blueprint_entities(dummyEntities)
+end
+
+--- Update all blueprints in a book, applying the replacerFunction to every entity. Recurs into books inside.
+-- @tparam LuaItemStack stack
+-- @tparam func replacerFunction
+blueprints.updateBlueprintBook = function(stack, replacerFunction)
+    --Safety checks: make sure stack is a blueprint book and valid
+   if not stack then return end
+   if not stack.valid_for_read then return end
+   if not stack.is_blueprint_book then return end
+
+   -- Get the underlying inventory item
+   local book = stack.get_inventory(defines.inventory.item_main)
+
+   --Iterate through all blueprints in the book
+   for i=1, #book do
+      local bp = book[i]
+      if bp and bp.valid and bp.valid_for_read then
+         -- Update any blueprints
+         if bp.is_blueprint then
+            blueprints.updateSingleBlueprint(bp, replacerFunction)
+
+         -- Update any books recursively
+         elseif bp.is_blueprint_book then
+            blueprints.updateBlueprintBook(bp, replacerFunction)
+         end
+      end
+   end
+end
+
 
 blueprints.bpReplacerToDummy = function(entity)
     if (waterGhostCommon.dummyEntityPrototypeExists(entity.name)) then


### PR DESCRIPTION
This changes behavior for blueprint books. With this change, if a blueprint book is held in the cursor, all blueprints in the book are updated. This is done recursively, updating any books within the book, too.

This was requested in https://mods.factorio.com/mod/GhostOnWater/discussion/636127bf321a67b094934dfb, and I agree with the request. I have a large blueprint book of train blueprints, and I'd like to update all of them in one pass. I have another book of hundreds of belt balancers - and likewise I want that to be updated in one go. Writing this PR was honestly quicker than doing each update one-by-one!

I haven't updated the changelog or any documentation; let me know whether you'd like me to do that or you prefer to do it yourself.