### PR TITLE
remove valid crafting categories from the dummy entities.

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -2,3 +2,5 @@
 require("prototypes/inputs")
 --load groups
 require("prototypes/groups")
+--load categories
+require("prototypes/categories")

--- a/prototypes/categories.lua
+++ b/prototypes/categories.lua
@@ -1,0 +1,3 @@
+data:extend({
+    { type = "recipe-category", name = "dummy" }
+  })

--- a/prototypes/categories.lua
+++ b/prototypes/categories.lua
@@ -1,3 +1,5 @@
+local constants = require('modules/constants')
+
 data:extend({
-    { type = "recipe-category", name = "dummy" }
+    { type = "recipe-category", name = constants.dummyPrefix }
   })

--- a/prototypes/dummyGenerator.lua
+++ b/prototypes/dummyGenerator.lua
@@ -247,7 +247,9 @@ local function createDummyEntity(originalEntity)
 
     --remove existing crafting categories from the dummy entity so factory planners don't see them as valid machines
     --factorio requires the entity to have 'a' crafting category, so we replace it with a dummy category that has no recipes
-    dummyEntity.crafting_categories = {"dummy"}
+    if dummyEntity.crafting_categories ~= nil then
+        dummyEntity.crafting_categories = { constants.dummyPrefix }
+    end
 
 
     --generate localisation from the original entity

--- a/prototypes/dummyGenerator.lua
+++ b/prototypes/dummyGenerator.lua
@@ -245,6 +245,11 @@ local function createDummyEntity(originalEntity)
     --remove any autoplace spec in the entity
     dummyEntity.autoplace = nil
 
+    --remove existing crafting categories from the dummy entity so factory planners don't see them as valid machines
+    --factorio requires the entity to have 'a' crafting category, so we replace it with a dummy category that has no recipes
+    dummyEntity.crafting_categories = {"dummy"}
+
+
     --generate localisation from the original entity
     dummyEntity.localised_name = {"", originalEntity.localised_name or {"entity-name." .. originalEntity.name}, " - ", {"dummy_name_suffix"}}
 


### PR DESCRIPTION
this will prevent planning mods from considering the dummy machines